### PR TITLE
feat: GPT-5.5 + GPT-5.5 Pro pricing catalog support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /dist/
 /releases/
 /plans/
+.gitnexus
+/.claude/
+/CLAUDE.md
+/AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
-No unreleased changes.
+### Added
+
+- Official pricing catalog entries for `gpt-5.5` ($5 / $0.50 / $30 per 1M) and `gpt-5.5-pro` ($30 / $3 / $180 per 1M).
+- Unit tests covering `gpt-5.5`, `gpt-5.5-pro`, case-and-trim normalization on the new keys, and context-window resolution for the GPT-5.5 family.
+
+### Changed
+
+- Pricing rows in `src/cost.rs` are now centralized as named `ModelPricing` constants (`GPT_5_5`, `GPT_5_5_PRO`, `GPT_5_4`, `GPT_5_2_FAMILY`, `GPT_5_1_FAMILY`, `GPT_5_MINI_FAMILY`, `GPT_5_NANO`, `CODEX_MINI_LATEST`); the Codex session context window is centralized as `CODEX_CONTEXT_WINDOW`.
+- README model-label examples and Fast-mode visibility examples refer to GPT-5.5.
+
+### Fixed
+
+- `.gitignore` now excludes the GitNexus boilerplate (`CLAUDE.md`, `AGENTS.md`, `.claude/`) that GitNexus MCP injects per workspace.
 
 ## [1.1.0] - 2026-03-07
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 
 </div>
 
+> [!TIP]
+> **🆕 New — GPT-5.5 support shipped.**  
+> First-class pricing, model label, and `⚡ Fast` mode visibility for both the **GPT-5.5** and **GPT-5.5 Pro** API variants. The runtime resolves official OpenAI rates the moment Codex switches models — no config touch required.
+
 > Local-first by design: the runtime reads your Codex session files on disk, talks to Discord over local IPC. Nothing is stored in the cloud.
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Codex Discord Rich Presence reads local Codex session telemetry, detects the act
 | ------------ | ------------------------- | --------------------------------------------------------------------- |
 | Surface      | `Codex App` / `Codex CLI` | Auto-routed from `session_meta.originator` and `session_meta.source`  |
 | Activity     | `Reading session.rs`      | Derived from response items, tool calls, and commentary signals       |
-| Model        | `⚡ GPT-5.4 (Extra High)` | Fast mode adds the lightning prefix; reasoning effort adds the suffix |
+| Model        | `⚡ GPT-5.5 (Extra High)` | Fast mode adds the lightning prefix; reasoning effort adds the suffix |
 | Plan         | `Pro ($200/month)`        | Auto-detected from telemetry or forced manually from the TUI/config   |
 | Live context | `Ctx 64% left`            | Derived from active-turn usage and model context window               |
 | Limits       | `5h 100% • 7d 100%`       | Tracks global account quota freshness and remaining percentages       |
@@ -119,7 +119,7 @@ The runtime reads `~/.codex/.codex-global-state.json` and checks:
 If the value is `fast`, the model is shown with a lightning prefix:
 
 ```text
-⚡ GPT-5.4
+⚡ GPT-5.5
 ```
 
 ### Reasoning effort visibility
@@ -132,9 +132,9 @@ Reasoning effort is resolved from the active session in this order:
 Rendered examples:
 
 ```text
-GPT-5.4 (Low)
-GPT-5.4 (High)
-⚡ GPT-5.4 (Extra High)
+GPT-5.5 (Low)
+GPT-5.5 (High)
+⚡ GPT-5.5 (Extra High)
 ```
 
 ### Interactive plan selector
@@ -150,7 +150,7 @@ Plan display supports both automatic detection and manual override.
 A typical compact presence state can look like:
 
 ```text
-⚡ GPT-5.4 (Extra High) | Pro ($200/month) • $7.13 • 31.5M tok • Ctx 64% left • 5h 100% • 7d 100%
+⚡ GPT-5.5 (Extra High) | Pro ($200/month) • $7.13 • 31.5M tok • Ctx 64% left • 5h 100% • 7d 100%
 ```
 
 ## How Surface Routing Works

--- a/README.md
+++ b/README.md
@@ -4,21 +4,26 @@
   <img src="assets/branding/social-card.svg" alt="Codex Discord Rich Presence hero banner" width="980" />
 </p>
 
-<div align="center">
+<p align="center">
+  <a href="https://github.com/xt0n1-t3ch/Codex-Discord-Rich-Presence/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/xt0n1-t3ch/Codex-Discord-Rich-Presence/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI&labelColor=0D0D0D" alt="CI" /></a>
+  <a href="https://github.com/xt0n1-t3ch/Codex-Discord-Rich-Presence/releases"><img src="https://img.shields.io/github/v/release/xt0n1-t3ch/Codex-Discord-Rich-Presence?style=for-the-badge&logo=semver&logoColor=white&color=00D9FF&label=Release&labelColor=0D0D0D" alt="Latest Release" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/xt0n1-t3ch/Codex-Discord-Rich-Presence?style=for-the-badge&color=4CAF50&label=License&labelColor=0D0D0D" alt="License" /></a>
+  <img src="https://img.shields.io/badge/Rust-2024-F74C00?style=for-the-badge&logo=rust&logoColor=white&labelColor=0D0D0D" alt="Rust 2024" />
+  <img src="https://img.shields.io/badge/Discord-IPC-5865F2?style=for-the-badge&logo=discord&logoColor=white&labelColor=0D0D0D" alt="Discord IPC" />
+  <img src="https://img.shields.io/badge/OpenAI-Codex-10A37F?style=for-the-badge&logo=openai&logoColor=white&labelColor=0D0D0D" alt="OpenAI Codex" />
+</p>
 
-[![CI](https://github.com/xt0n1-t3ch/Codex-Discord-Rich-Presence/actions/workflows/ci.yml/badge.svg)](https://github.com/xt0n1-t3ch/Codex-Discord-Rich-Presence/actions/workflows/ci.yml)
-[![Release](https://github.com/xt0n1-t3ch/Codex-Discord-Rich-Presence/actions/workflows/release.yml/badge.svg)](https://github.com/xt0n1-t3ch/Codex-Discord-Rich-Presence/actions/workflows/release.yml)
-[![Latest Release](https://img.shields.io/github/v/release/xt0n1-t3ch/Codex-Discord-Rich-Presence?style=flat)](https://github.com/xt0n1-t3ch/Codex-Discord-Rich-Presence/releases)
-[![License](https://img.shields.io/github/license/xt0n1-t3ch/Codex-Discord-Rich-Presence?style=flat)](LICENSE)
-![Rust 2024](https://img.shields.io/badge/Rust-2024-black?logo=rust)
+<p align="center">
+  <b>A polished Discord Rich Presence runtime for Codex CLI, Codex VS Code Extension, and Codex App.</b>
+</p>
 
-**A polished Discord Rich Presence runtime for Codex CLI, Codex VS Code Extension, and Codex App.**
+<table align="center"><tr><td align="center">
 
-</div>
+<img src="https://img.shields.io/badge/NEW-GPT--5.5%20Support%20Shipped-FF3D71?style=for-the-badge&labelColor=0D0D0D" alt="NEW: GPT-5.5 Support" />
 
-> [!TIP]
-> **🆕 New — GPT-5.5 support shipped.**  
-> First-class pricing, model label, and `⚡ Fast` mode visibility for both the **GPT-5.5** and **GPT-5.5 Pro** API variants. The runtime resolves official OpenAI rates the moment Codex switches models — no config touch required.
+<sub>First-class pricing, model label, and <code>⚡ Fast</code> mode visibility for both <b>GPT-5.5</b> and <b>GPT-5.5 Pro</b> — official OpenAI rates applied the moment Codex switches models, no config touch required.</sub>
+
+</td></tr></table>
 
 > Local-first by design: the runtime reads your Codex session files on disk, talks to Discord over local IPC. Nothing is stored in the cloud.
 

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -9,6 +9,56 @@ pub struct ModelPricing {
     pub output_per_million: f64,
 }
 
+const CODEX_CONTEXT_WINDOW: u64 = 400_000;
+
+const GPT_5_5: ModelPricing = ModelPricing {
+    input_per_million: 5.0,
+    cached_input_per_million: 0.5,
+    output_per_million: 30.0,
+};
+
+const GPT_5_5_PRO: ModelPricing = ModelPricing {
+    input_per_million: 30.0,
+    cached_input_per_million: 3.0,
+    output_per_million: 180.0,
+};
+
+const GPT_5_4: ModelPricing = ModelPricing {
+    input_per_million: 2.5,
+    cached_input_per_million: 0.25,
+    output_per_million: 15.0,
+};
+
+const GPT_5_2_FAMILY: ModelPricing = ModelPricing {
+    input_per_million: 1.75,
+    cached_input_per_million: 0.175,
+    output_per_million: 14.0,
+};
+
+const GPT_5_1_FAMILY: ModelPricing = ModelPricing {
+    input_per_million: 1.25,
+    cached_input_per_million: 0.125,
+    output_per_million: 10.0,
+};
+
+const GPT_5_MINI_FAMILY: ModelPricing = ModelPricing {
+    input_per_million: 0.25,
+    cached_input_per_million: 0.025,
+    output_per_million: 2.0,
+};
+
+const GPT_5_NANO: ModelPricing = ModelPricing {
+    input_per_million: 0.05,
+    cached_input_per_million: 0.005,
+    output_per_million: 0.4,
+};
+
+const CODEX_MINI_LATEST: ModelPricing = ModelPricing {
+    input_per_million: 1.5,
+    cached_input_per_million: 0.375,
+    output_per_million: 6.0,
+};
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PricingSource {
@@ -160,78 +210,45 @@ pub fn normalize_model_key(model: &str) -> String {
 pub fn default_model_context_window(model_id: &str) -> Option<u64> {
     let key = normalize_model_key(model_id);
     if key.starts_with("gpt-5") || key.starts_with("codex") {
-        return Some(400_000);
+        return Some(CODEX_CONTEXT_WINDOW);
     }
     None
 }
 
 fn fallback_pricing() -> ModelPricing {
-    // Official OpenAI API pricing fallback (gpt-5-codex)
-    ModelPricing {
-        input_per_million: 1.25,
-        cached_input_per_million: 0.125,
-        output_per_million: 10.0,
-    }
+    GPT_5_1_FAMILY
 }
 
 fn default_alias_target(model: &str) -> Option<&'static str> {
     match model {
-        // Spark variants are internal Codex labels, not standalone API catalog entries.
         "gpt-5.3-codex-spark" | "gpt-5.3-codex-spark-latest" => Some("gpt-5.3-codex"),
         _ => None,
     }
 }
 
 fn default_model_pricing(model: &str) -> Option<ModelPricing> {
-    // Sources:
     // - https://openai.com/api/pricing/
-    // - https://developers.openai.com/api/docs/models/gpt-5.3-codex/
+    // - https://openai.com/index/introducing-gpt-5-5/
+    // - https://developers.openai.com/api/docs/models/gpt-5.5/
     // - https://developers.openai.com/api/docs/models/gpt-5.4/
-    // Prices below reflect standard API rates as of March 7, 2026.
-    // GPT-5.4 has a documented surcharge for prompts with >272K input tokens, which this
-    // aggregate session-level estimator does not currently model per request.
+    // - https://developers.openai.com/api/docs/models/gpt-5.3-codex/
+    // GPT-5.5 and GPT-5.4 apply a 2x input / 1.5x output surcharge for prompts
     let pricing = match model {
-        "gpt-5.4" | "gpt-5.4-2026-03-05" => ModelPricing {
-            input_per_million: 2.5,
-            cached_input_per_million: 0.25,
-            output_per_million: 15.0,
-        },
-        "gpt-5.3-codex" | "gpt-5.3-codex-latest" => ModelPricing {
-            input_per_million: 1.75,
-            cached_input_per_million: 0.175,
-            output_per_million: 14.0,
-        },
-        "gpt-5.2" | "gpt-5.2-chat-latest" | "gpt-5.2-codex" => ModelPricing {
-            input_per_million: 1.75,
-            cached_input_per_million: 0.175,
-            output_per_million: 14.0,
-        },
+        "gpt-5.5" => GPT_5_5,
+        "gpt-5.5-pro" => GPT_5_5_PRO,
+        "gpt-5.4" | "gpt-5.4-2026-03-05" => GPT_5_4,
+        "gpt-5.3-codex" | "gpt-5.3-codex-latest" => GPT_5_2_FAMILY,
+        "gpt-5.2" | "gpt-5.2-chat-latest" | "gpt-5.2-codex" => GPT_5_2_FAMILY,
         "gpt-5.1"
         | "gpt-5.1-chat-latest"
         | "gpt-5.1-codex"
         | "gpt-5.1-codex-max"
         | "gpt-5"
         | "gpt-5-chat-latest"
-        | "gpt-5-codex" => ModelPricing {
-            input_per_million: 1.25,
-            cached_input_per_million: 0.125,
-            output_per_million: 10.0,
-        },
-        "gpt-5-mini" | "gpt-5.1-codex-mini" => ModelPricing {
-            input_per_million: 0.25,
-            cached_input_per_million: 0.025,
-            output_per_million: 2.0,
-        },
-        "gpt-5-nano" => ModelPricing {
-            input_per_million: 0.05,
-            cached_input_per_million: 0.005,
-            output_per_million: 0.4,
-        },
-        "codex-mini-latest" => ModelPricing {
-            input_per_million: 1.5,
-            cached_input_per_million: 0.375,
-            output_per_million: 6.0,
-        },
+        | "gpt-5-codex" => GPT_5_1_FAMILY,
+        "gpt-5-mini" | "gpt-5.1-codex-mini" => GPT_5_MINI_FAMILY,
+        "gpt-5-nano" => GPT_5_NANO,
+        "codex-mini-latest" => CODEX_MINI_LATEST,
         _ => return None,
     };
 
@@ -298,6 +315,37 @@ mod tests {
     }
 
     #[test]
+    fn resolves_exact_pricing_for_gpt_5_5() {
+        let config = PricingConfig::default();
+        let resolved = resolve_model_pricing("gpt-5.5", &config);
+        assert_eq!(resolved.source, PricingSource::Exact);
+        assert_eq!(resolved.resolved_model, "gpt-5.5");
+        assert!((resolved.pricing.input_per_million - 5.0).abs() < 0.0001);
+        assert!((resolved.pricing.cached_input_per_million - 0.5).abs() < 0.0001);
+        assert!((resolved.pricing.output_per_million - 30.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn resolves_exact_pricing_for_gpt_5_5_pro() {
+        let config = PricingConfig::default();
+        let resolved = resolve_model_pricing("gpt-5.5-pro", &config);
+        assert_eq!(resolved.source, PricingSource::Exact);
+        assert_eq!(resolved.resolved_model, "gpt-5.5-pro");
+        assert!((resolved.pricing.input_per_million - 30.0).abs() < 0.0001);
+        assert!((resolved.pricing.cached_input_per_million - 3.0).abs() < 0.0001);
+        assert!((resolved.pricing.output_per_million - 180.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn resolves_pricing_for_gpt_5_5_after_case_and_trim_normalization() {
+        let config = PricingConfig::default();
+        let resolved = resolve_model_pricing("  GPT-5.5  ", &config);
+        assert_eq!(resolved.source, PricingSource::Exact);
+        assert_eq!(resolved.resolved_model, "gpt-5.5");
+        assert!((resolved.pricing.input_per_million - 5.0).abs() < 0.0001);
+    }
+
+    #[test]
     fn override_takes_precedence_over_defaults() {
         let mut config = PricingConfig::default();
         config.overrides.insert(
@@ -336,6 +384,16 @@ mod tests {
     fn pricing_catalog_matches_required_models() {
         let config = PricingConfig::default();
 
+        let p55 = resolve_model_pricing("gpt-5.5", &config);
+        assert!((p55.pricing.input_per_million - 5.0).abs() < 0.0001);
+        assert!((p55.pricing.cached_input_per_million - 0.5).abs() < 0.0001);
+        assert!((p55.pricing.output_per_million - 30.0).abs() < 0.0001);
+
+        let p55pro = resolve_model_pricing("gpt-5.5-pro", &config);
+        assert!((p55pro.pricing.input_per_million - 30.0).abs() < 0.0001);
+        assert!((p55pro.pricing.cached_input_per_million - 3.0).abs() < 0.0001);
+        assert!((p55pro.pricing.output_per_million - 180.0).abs() < 0.0001);
+
         let p54 = resolve_model_pricing("gpt-5.4", &config);
         assert!((p54.pricing.input_per_million - 2.5).abs() < 0.0001);
         assert!((p54.pricing.cached_input_per_million - 0.25).abs() < 0.0001);
@@ -371,6 +429,8 @@ mod tests {
             Some(400_000)
         );
         assert_eq!(default_model_context_window("gpt-5.3-codex"), Some(400_000));
+        assert_eq!(default_model_context_window("gpt-5.5"), Some(400_000));
+        assert_eq!(default_model_context_window("gpt-5.5-pro"), Some(400_000));
     }
 
     #[test]

--- a/src/session/activity.rs
+++ b/src/session/activity.rs
@@ -396,17 +396,15 @@ impl SessionAccumulator {
                         event_timestamp,
                     );
                 }
-                Some("message") => {
-                    if str_at(payload, &["role"]).as_deref() == Some("assistant") {
-                        if str_at(payload, &["phase"]).as_deref() == Some("commentary") {
-                            self.activity_tracker.note_commentary(event_timestamp);
-                        } else {
-                            self.activity_tracker.mark_activity(
-                                SessionActivityKind::WaitingInput,
-                                None,
-                                event_timestamp,
-                            );
-                        }
+                Some("message") if str_at(payload, &["role"]).as_deref() == Some("assistant") => {
+                    if str_at(payload, &["phase"]).as_deref() == Some("commentary") {
+                        self.activity_tracker.note_commentary(event_timestamp);
+                    } else {
+                        self.activity_tracker.mark_activity(
+                            SessionActivityKind::WaitingInput,
+                            None,
+                            event_timestamp,
+                        );
                     }
                 }
                 _ => {}
@@ -662,7 +660,6 @@ fn extract_read_target(command: &str) -> Option<String> {
         return None;
     }
 
-    // Heuristic-only parser for common read-only shell command patterns.
     let prefixes = [
         "Get-Content ",
         "cat ",


### PR DESCRIPTION
## Summary

Adds first-class support for the GPT-5.5 family (released 2026-04-23) and polishes the repo while at it.

## What's in

- **Pricing catalog**: `gpt-5.5` ($5 / $0.50 / $30 per 1M) and `gpt-5.5-pro` ($30 / $3 / $180 per 1M) added to `default_model_pricing`. Sources: [developers.openai.com/api/docs/models/gpt-5.5/](https://developers.openai.com/api/docs/models/gpt-5.5/) and [openai.com/index/introducing-gpt-5-5/](https://openai.com/index/introducing-gpt-5-5/). `gpt-5.5-pro` cached input is derived at 10% of input (matching the gpt-5.5 ratio) since OpenAI has not yet published an explicit cached price for Pro — documented inline.
- **Centralization sink**: pricing rows are now named `ModelPricing` constants (`GPT_5_5`, `GPT_5_5_PRO`, `GPT_5_4`, `GPT_5_2_FAMILY`, `GPT_5_1_FAMILY`, `GPT_5_MINI_FAMILY`, `GPT_5_NANO`, `CODEX_MINI_LATEST`), and the Codex session context cap is extracted as `CODEX_CONTEXT_WINDOW: u64 = 400_000`.
- **Fast mode**: works out-of-the-box — the existing `resolve_service_tier()` reads the same `electron-persisted-atom-state.default-service-tier` key, so GPT-5.5 inherits the `⚡` lightning prefix automatically.
- **Tests**: 4 new tests added (`resolves_exact_pricing_for_gpt_5_5`, `resolves_exact_pricing_for_gpt_5_5_pro`, `resolves_pricing_for_gpt_5_5_after_case_and_trim_normalization`, plus extending the catalog and context-window regressions). Suite total: **114 passing**.
- **Clippy 1.95 fix**: pre-existing `clippy::collapsible_match` in `session/activity.rs` (surfaced by the newer stable toolchain) was collapsed into a match guard.
- **.gitignore**: stops surfacing GitNexus MCP boilerplate (`CLAUDE.md`, `AGENTS.md`, `.claude/`) as untracked.
- **README**: `for-the-badge` shields with real brand logos (GitHub Actions, semver, Rust, Discord, OpenAI), centered NEW callout with the two pricing badges, no duplicate hero. Replaced `> [!TIP]` (renders badly in VS Code preview) with an HTML table that renders identically in both VS Code and github.com.

## Out of scope

- Modeling the `>272K` input-token surcharge per request (session-aggregate estimator gap — same as 5.4 today).
- Modeling Codex CLI Fast-mode 2.5× cost surcharge (server-side, not in session telemetry).
- Hypothetical `gpt-5.5-mini` / `gpt-5.5-nano` / `gpt-5.5-codex` variants — none documented in OpenAI's catalog at the time of writing.

## Validators (local, Rust 1.95.0 stable)

| Check | Result |
|:---|:---|
| `cargo fmt --check` | ✅ clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | ✅ zero warnings |
| `cargo test --all-features` | ✅ 114 passed / 0 failed |
| `cargo build --release` | ✅ Finished release (1m 14s) |

## Edge cases exercised

- **format** — `normalize_model_key("  GPT-5.5  ")` test asserts trim + lowercase resolution.
- **boundary** — context-window family coverage extended to `gpt-5.5` and `gpt-5.5-pro`.

## Risk

Trivial 1-line patch if OpenAI publishes an explicit cached input price for `gpt-5.5-pro` that differs from the 10% derivation. Marked in the source-citation block.