### PR TITLE
fix(release): verify complete asset set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
           test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.draft')" = "true"
           mapfile -t actual_assets < <(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" --paginate --jq '.[].name' | sort)
           mapfile -t expected_assets < <(find release-assets -maxdepth 1 -type f -printf '%f\n' | sort)
-          test "${#actual_assets[@]}" -eq 6
+          test "${#actual_assets[@]}" -eq 7
           diff <(printf '%s\n' "${expected_assets[@]}") <(printf '%s\n' "${actual_assets[@]}")
 
           gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" --paginate \

--- a/tests/release_workflow.tests.ps1
+++ b/tests/release_workflow.tests.ps1
@@ -140,6 +140,7 @@ Assert-Matches 'SHA256SUMS\.txt' $publish "Publish must prove the checksum manif
 Assert-Matches 'draft: true' $publish "Assets must be attached while the release is a draft."
 Assert-Matches 'steps\.draft-release\.outputs\.id' $publish "Draft verification and finalization must use the created release id."
 Assert-Matches 'Verify draft release assets' $publish "Draft assets must be verified before publication."
+Assert-Matches 'test "\$\{#actual_assets\[@\]\}" -eq 7' $publish "Draft verification must require all six payloads plus the checksum manifest."
 Assert-Matches '\.digest' $publish "Draft verification must compare GitHub asset digests with local SHA-256 values."
 Assert-Matches 'Finalize release once' $publish "The workflow must have one explicit finalization step."
 Assert-Matches '\{draft: false, prerelease: \$prerelease, make_latest: \$make_latest\}' $publish "Finalization must publish the verified draft exactly once."


### PR DESCRIPTION
## Summary

- require all seven published assets: six payloads plus `SHA256SUMS.txt`
- pin the invariant in the release workflow contract test
- prevent the immutable v1.7.2 release from failing after its draft is created

## Proof

- `tests/release_workflow.tests.ps1` failed before the workflow fix
- all five PowerShell release contract suites pass after the fix
- `git diff --check` passes

Closes #13