### PR TITLE
fix(release): assemble downloaded target artifacts

### DIFF
--- a/scripts/release-assets.ps1
+++ b/scripts/release-assets.ps1
@@ -16,13 +16,12 @@ function Find-RequiredArtifact {
         [System.IO.FileInfo[]] $Files,
 
         [Parameter(Mandatory)]
-        [string] $PathSuffix
+        [string] $FileName
     )
 
-    $normalizedSuffix = "/" + $PathSuffix.Replace("\", "/").TrimStart("/")
-    $matches = @($Files | Where-Object { $_.FullName.Replace("\", "/").EndsWith($normalizedSuffix, [System.StringComparison]::Ordinal) })
+    $matches = @($Files | Where-Object { $_.Name -ceq $FileName })
     if ($matches.Count -ne 1) {
-        throw "Expected exactly one artifact ending in '$PathSuffix', found $($matches.Count)."
+        throw "Expected exactly one artifact named '$FileName', found $($matches.Count)."
     }
 
     return $matches[0]
@@ -40,10 +39,10 @@ try {
     }
 
     $sources = [ordered]@{
-        "codex-discord-rich-presence-windows-x64.exe" = Find-RequiredArtifact -Files $files -PathSuffix "windows/codex-discord-rich-presence-windows-x64.exe"
-        "codex-discord-rich-presence-linux-x64" = Find-RequiredArtifact -Files $files -PathSuffix "linux/codex-discord-rich-presence-linux-x64"
-        "codex-discord-rich-presence-macos-x64" = Find-RequiredArtifact -Files $files -PathSuffix "macos/codex-discord-rich-presence-macos-x64"
-        "codex-discord-rich-presence-macos-arm64" = Find-RequiredArtifact -Files $files -PathSuffix "macos/codex-discord-rich-presence-macos-arm64"
+        "codex-discord-rich-presence-windows-x64.exe" = Find-RequiredArtifact -Files $files -FileName "codex-discord-rich-presence-windows-x64.exe"
+        "codex-discord-rich-presence-linux-x64" = Find-RequiredArtifact -Files $files -FileName "codex-discord-rich-presence-linux-x64"
+        "codex-discord-rich-presence-macos-x64" = Find-RequiredArtifact -Files $files -FileName "codex-discord-rich-presence-macos-x64"
+        "codex-discord-rich-presence-macos-arm64" = Find-RequiredArtifact -Files $files -FileName "codex-discord-rich-presence-macos-arm64"
     }
 
     $logos = @($files | Where-Object { $_.Name -eq "codex-app-logo.png" })

--- a/tests/release_assets.tests.ps1
+++ b/tests/release_assets.tests.ps1
@@ -76,12 +76,12 @@ try {
 
     $artifactRoot = Join-Path $temporaryRoot "downloaded"
     $outputDirectory = Join-Path $temporaryRoot "release-assets"
-    Add-FixtureFile -Root $artifactRoot -RelativePath "windows-x64/releases/windows/codex-discord-rich-presence-windows-x64.exe" -Content "windows-binary"
-    Add-FixtureFile -Root $artifactRoot -RelativePath "linux-x64/releases/linux/codex-discord-rich-presence-linux-x64" -Content "linux-binary"
-    Add-FixtureFile -Root $artifactRoot -RelativePath "macos-x64/releases/macos/codex-discord-rich-presence-macos-x64" -Content "macos-x64-binary"
-    Add-FixtureFile -Root $artifactRoot -RelativePath "macos-arm64/releases/macos/codex-discord-rich-presence-macos-arm64" -Content "macos-arm64-binary"
-    Add-FixtureFile -Root $artifactRoot -RelativePath "windows-x64/releases/windows/codex-app-logo.png" -Content "logo"
-    Add-FixtureFile -Root $artifactRoot -RelativePath "windows-x64/releases/windows/chatgpt-app-logo.jpg" -Content "chatgpt-logo"
+    Add-FixtureFile -Root $artifactRoot -RelativePath "release-x86_64-pc-windows-msvc/codex-discord-rich-presence-windows-x64.exe" -Content "windows-binary"
+    Add-FixtureFile -Root $artifactRoot -RelativePath "release-x86_64-unknown-linux-gnu/codex-discord-rich-presence-linux-x64" -Content "linux-binary"
+    Add-FixtureFile -Root $artifactRoot -RelativePath "release-x86_64-apple-darwin/codex-discord-rich-presence-macos-x64" -Content "macos-x64-binary"
+    Add-FixtureFile -Root $artifactRoot -RelativePath "release-aarch64-apple-darwin/codex-discord-rich-presence-macos-arm64" -Content "macos-arm64-binary"
+    Add-FixtureFile -Root $artifactRoot -RelativePath "release-x86_64-pc-windows-msvc/codex-app-logo.png" -Content "logo"
+    Add-FixtureFile -Root $artifactRoot -RelativePath "release-x86_64-pc-windows-msvc/chatgpt-app-logo.jpg" -Content "chatgpt-logo"
 
     $complete = Invoke-AssetBuild -ArtifactRoot $artifactRoot -OutputDirectory $outputDirectory
     Assert-Equal 0 $complete.ExitCode "A complete artifact set must pass."


### PR DESCRIPTION
## Summary

- match the directory layout produced by `actions/download-artifact`
- identify each target binary by its unique published filename
- replace the synthetic nested-path fixture with GitHub's real artifact layout

## TDD and proof

- the corrected fixture failed against the previous assembler
- all five release contract suites pass
- the assembler succeeds against artifacts downloaded from failed run `29056102990`
- output contains seven files and all six manifest hashes verify

This fixes the pre-publication failure in the v1.7.2 release pipeline. No draft or release was created.